### PR TITLE
Fix warning CS0649

### DIFF
--- a/addons/imgui-godot/ImGuiNode.cs
+++ b/addons/imgui-godot/ImGuiNode.cs
@@ -5,8 +5,10 @@ using ImGuiNET;
 
 public class ImGuiNode : Node2D
 {
+#pragma warning disable 0649
     [Export]
     DynamicFont Font = null;
+#pragma warning restore 0649
 
     [Signal]
     public delegate void IGLayout();


### PR DESCRIPTION
When building the game, the C# compiler complains about CS0649. As I see it, the font is expected to be assigned in the Godot editor, not via code, so this should be made clear to the compiler.