### PR TITLE
Add Key and Joybutton extension to convert to ImGui types

### DIFF
--- a/addons/imgui-godot/ImGuiGodot/ImGuiGD.cs
+++ b/addons/imgui-godot/ImGuiGodot/ImGuiGD.cs
@@ -75,5 +75,21 @@ namespace ImGuiGodot
         {
             return ImGuiGDInternal.ProcessInput(evt);
         }
+
+        /// <summary>
+        /// Extension method to translate between <see cref="Key"/> and <see cref="ImGuiKey"/>
+        /// </summary>
+        public static ImGuiKey ToImGuiKey(this Key key)
+        {
+            return ImGuiGDInternal.ConvertKey(key);
+        }
+
+        /// <summary>
+        /// Extension method to translate between <see cref="JoyButton"/> and <see cref="ImGuiKey"/>
+        /// </summary>
+        public static ImGuiKey ToImGuiKey(this JoyButton button)
+        {
+            return ImGuiGDInternal.ConvertJoyButton(button);
+        }
     }
 }

--- a/addons/imgui-godot/ImGuiGodot/ImGuiGDInternal.cs
+++ b/addons/imgui-godot/ImGuiGodot/ImGuiGDInternal.cs
@@ -421,7 +421,7 @@ namespace ImGuiGodot
             _ => CursorShape.Arrow,
         };
 
-        private static ImGuiKey ConvertJoyButton(JoyButton btn) => btn switch
+        public static ImGuiKey ConvertJoyButton(JoyButton btn) => btn switch
         {
             JoyButton.Start => ImGuiKey.GamepadStart,
             JoyButton.Back => ImGuiKey.GamepadBack,
@@ -440,7 +440,7 @@ namespace ImGuiGodot
             _ => ImGuiKey.None
         };
 
-        private static ImGuiKey ConvertKey(Key k) => k switch
+        public static ImGuiKey ConvertKey(Key k) => k switch
         {
             Key.Tab => ImGuiKey.Tab,
             Key.Left => ImGuiKey.LeftArrow,


### PR DESCRIPTION
The PR allows for Godot developers to check against Godot keycodes in an ImGUI window.

Improves on: https://github.com/pkdawson/imgui-godot/pull/12