### PR TITLE
Use new GodotSharp .NET naming conventions

### DIFF
--- a/addons/imgui-godot/ImGuiGodot/ImGuiAPI.cs
+++ b/addons/imgui-godot/ImGuiGodot/ImGuiAPI.cs
@@ -83,7 +83,7 @@ public partial class ImGuiAPI : Godot.Object
 
     public bool Button(string label, Vector2 size)
     {
-        return ImGui.Button(label, new(size.x, size.y));
+        return ImGui.Button(label, new(size.X, size.Y));
     }
 }
 #pragma warning restore CA1822 // Mark members as static

--- a/addons/imgui-godot/ImGuiGodot/ImGuiGD.cs
+++ b/addons/imgui-godot/ImGuiGodot/ImGuiGD.cs
@@ -111,7 +111,7 @@ public static class ImGuiGD
     {
         var io = ImGui.GetIO();
         var vpSize = vp.GetVisibleRect().Size;
-        io.DisplaySize = new(vpSize.x, vpSize.y);
+        io.DisplaySize = new(vpSize.X, vpSize.Y);
         io.DeltaTime = (float)delta;
 
         Internal.Input.Update(io);
@@ -182,7 +182,7 @@ public static class ImGuiGD
     /// </summary>
     public static Vector4 ToVector4(this Color color)
     {
-        return new Vector4(color.r, color.g, color.b, color.a);
+        return new Vector4(color.R, color.G, color.B, color.A);
     }
 
     /// <summary>
@@ -190,7 +190,7 @@ public static class ImGuiGD
     /// </summary>
     public static Vector3 ToVector3(this Color color)
     {
-        return new Vector3(color.r, color.g, color.b);
+        return new Vector3(color.R, color.G, color.B);
     }
 
     /// <summary>

--- a/addons/imgui-godot/ImGuiGodot/ImGuiLayer.cs
+++ b/addons/imgui-godot/ImGuiGodot/ImGuiLayer.cs
@@ -43,7 +43,7 @@ public partial class ImGuiLayer : CanvasLayer
     private SubViewportContainer _subViewportContainer;
     private SubViewport _subViewport;
     private UpdateFirst _updateFirst;
-    private static readonly HashSet<Godot.Object> _connectedObjects = new();
+    private static readonly HashSet<GodotObject> _connectedObjects = new();
     private int sizeCheck = 0;
     private bool _headless = false;
 
@@ -188,7 +188,7 @@ public partial class ImGuiLayer : CanvasLayer
 
     public override void _Process(double delta)
     {
-        EmitSignal(SignalName.ImGuiLayout);
+        //EmitSignal(SignalName.ImGuiLayout);
         ImGuiGD.Render(_subViewport);
     }
 
@@ -205,6 +205,7 @@ public partial class ImGuiLayer : CanvasLayer
         }
     }
 
+    /*
     public static void Connect(ImGuiLayoutEventHandler d)
     {
         if (Instance is null)
@@ -212,7 +213,7 @@ public partial class ImGuiLayer : CanvasLayer
 
         Instance.ImGuiLayout += d;
 
-        if (d.Target is Godot.Object obj)
+        if (d.Target is GodotObject obj)
         {
             if (_connectedObjects.Count == 0)
             {
@@ -221,6 +222,7 @@ public partial class ImGuiLayer : CanvasLayer
             _connectedObjects.Add(obj);
         }
     }
+    */
 
 #if IMGUI_GODOT_DEV
 #pragma warning disable CA1822 // Mark members as static
@@ -262,6 +264,7 @@ public partial class ImGuiLayer : CanvasLayer
 
         _connectedObjects.Remove(node);
 
+        /*
         // backing_ImGuiLayout is an implementation detail that could change
         foreach (Delegate d in Instance.backing_ImGuiLayout.GetInvocationList())
         {
@@ -271,6 +274,7 @@ public partial class ImGuiLayer : CanvasLayer
                 Instance.ImGuiLayout -= (ImGuiLayoutEventHandler)d;
             }
         }
+        */
 
         if (_connectedObjects.Count == 0)
         {

--- a/addons/imgui-godot/ImGuiGodot/ImGuiLayer.cs
+++ b/addons/imgui-godot/ImGuiGodot/ImGuiLayer.cs
@@ -188,7 +188,7 @@ public partial class ImGuiLayer : CanvasLayer
 
     public override void _Process(double delta)
     {
-        //EmitSignal(SignalName.ImGuiLayout);
+        EmitSignal(SignalName.ImGuiLayout);
         ImGuiGD.Render(_subViewport);
     }
 
@@ -205,7 +205,6 @@ public partial class ImGuiLayer : CanvasLayer
         }
     }
 
-    /*
     public static void Connect(ImGuiLayoutEventHandler d)
     {
         if (Instance is null)
@@ -222,7 +221,6 @@ public partial class ImGuiLayer : CanvasLayer
             _connectedObjects.Add(obj);
         }
     }
-    */
 
 #if IMGUI_GODOT_DEV
 #pragma warning disable CA1822 // Mark members as static
@@ -264,7 +262,6 @@ public partial class ImGuiLayer : CanvasLayer
 
         _connectedObjects.Remove(node);
 
-        /*
         // backing_ImGuiLayout is an implementation detail that could change
         foreach (Delegate d in Instance.backing_ImGuiLayout.GetInvocationList())
         {
@@ -274,7 +271,6 @@ public partial class ImGuiLayer : CanvasLayer
                 Instance.ImGuiLayout -= (ImGuiLayoutEventHandler)d;
             }
         }
-        */
 
         if (_connectedObjects.Count == 0)
         {

--- a/addons/imgui-godot/ImGuiGodot/Internal/CanvasRenderer.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/CanvasRenderer.cs
@@ -27,14 +27,14 @@ internal class CanvasRenderer : IRenderer
 
     public void InitViewport(Viewport vp)
     {
-        Rid vpRid = vp.GetViewportRid();
+        Rid vprid = vp.GetViewportRid();
 
         Rid canvas = RenderingServer.CanvasCreate();
         Rid canvasItem = RenderingServer.CanvasItemCreate();
-        RenderingServer.ViewportAttachCanvas(vpRid, canvas);
+        RenderingServer.ViewportAttachCanvas(vprid, canvas);
         RenderingServer.CanvasItemSetParent(canvasItem, canvas);
 
-        _vpData[vpRid] = new ViewportData()
+        _vpData[vprid] = new ViewportData()
         {
             Canvas = canvas,
             RootCanvasItem = canvasItem,

--- a/addons/imgui-godot/ImGuiGodot/Internal/CanvasRenderer.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/CanvasRenderer.cs
@@ -10,12 +10,12 @@ internal class CanvasRenderer : IRenderer
 {
     private class ViewportData
     {
-        public RID Canvas { set; get; }
-        public RID RootCanvasItem { set; get; }
+        public Rid Canvas { set; get; }
+        public Rid RootCanvasItem { set; get; }
     }
 
-    private readonly Dictionary<RID, List<RID>> _canvasItemPools = new();
-    private readonly Dictionary<RID, ViewportData> _vpData = new();
+    private readonly Dictionary<Rid, List<Rid>> _canvasItemPools = new();
+    private readonly Dictionary<Rid, ViewportData> _vpData = new();
 
     public string Name => "imgui_impl_godot4_canvas";
 
@@ -27,14 +27,14 @@ internal class CanvasRenderer : IRenderer
 
     public void InitViewport(Viewport vp)
     {
-        RID vprid = vp.GetViewportRid();
+        Rid vpRid = vp.GetViewportRid();
 
-        RID canvas = RenderingServer.CanvasCreate();
-        RID canvasItem = RenderingServer.CanvasItemCreate();
-        RenderingServer.ViewportAttachCanvas(vprid, canvas);
+        Rid canvas = RenderingServer.CanvasCreate();
+        Rid canvasItem = RenderingServer.CanvasItemCreate();
+        RenderingServer.ViewportAttachCanvas(vpRid, canvas);
         RenderingServer.CanvasItemSetParent(canvasItem, canvas);
 
-        _vpData[vprid] = new ViewportData()
+        _vpData[vpRid] = new ViewportData()
         {
             Canvas = canvas,
             RootCanvasItem = canvasItem,
@@ -44,7 +44,7 @@ internal class CanvasRenderer : IRenderer
     public void RenderDrawData(Viewport vp, ImDrawDataPtr drawData)
     {
         ViewportData vd = _vpData[vp.GetViewportRid()];
-        RID parent = vd.RootCanvasItem;
+        Rid parent = vd.RootCanvasItem;
 
         var window = (GodotImGuiWindow)GCHandle.FromIntPtr(drawData.OwnerViewport.PlatformHandle).Target;
 
@@ -68,7 +68,7 @@ internal class CanvasRenderer : IRenderer
 
         while (children.Count < neededNodes)
         {
-            RID newChild = RenderingServer.CanvasItemCreate();
+            Rid newChild = RenderingServer.CanvasItemCreate();
             RenderingServer.CanvasItemSetParent(newChild, parent);
             RenderingServer.CanvasItemSetDrawIndex(newChild, children.Count);
             children.Add(newChild);
@@ -145,14 +145,14 @@ internal class CanvasRenderer : IRenderer
                     Array.Copy(uvs, drawCmd.VtxOffset, cmduvs, 0, localSize);
                 }
 
-                RID child = children[nodeN++];
+                Rid child = children[nodeN++];
 
-                RID texrid = Util.ConstructRID((ulong)drawCmd.GetTexID());
+                Rid texRid = Util.ConstructRid((ulong)drawCmd.GetTexID());
                 RenderingServer.CanvasItemClear(child);
                 Transform2D xform = Transform2D.Identity;
                 if (drawData.DisplayPos != System.Numerics.Vector2.Zero)
                 {
-                    xform = xform.Translated(drawData.DisplayPos.ToVector2i()).Inverse();
+                    xform = xform.Translated(drawData.DisplayPos.ToVector2I()).Inverse();
                 }
                 RenderingServer.CanvasItemSetTransform(child, xform);
                 RenderingServer.CanvasItemSetClip(child, true);
@@ -163,7 +163,7 @@ internal class CanvasRenderer : IRenderer
                     drawCmd.ClipRect.W - drawCmd.ClipRect.Y)
                 );
 
-                RenderingServer.CanvasItemAddTriangleArray(child, indices, cmdvertices, cmdcolors, cmduvs, null, null, texrid, -1);
+                RenderingServer.CanvasItemAddTriangleArray(child, indices, cmdvertices, cmdcolors, cmduvs, null, null, texRid, -1);
             }
         }
     }
@@ -191,9 +191,9 @@ internal class CanvasRenderer : IRenderer
         }
     }
 
-    private void ClearCanvasItems(RID rootci)
+    private void ClearCanvasItems(Rid rootci)
     {
-        foreach (RID ci in _canvasItemPools[rootci])
+        foreach (Rid ci in _canvasItemPools[rootci])
         {
             RenderingServer.FreeRid(ci);
         }
@@ -201,7 +201,7 @@ internal class CanvasRenderer : IRenderer
 
     private void ClearCanvasItems()
     {
-        foreach (RID parent in _canvasItemPools.Keys)
+        foreach (Rid parent in _canvasItemPools.Keys)
         {
             ClearCanvasItems(parent);
         }

--- a/addons/imgui-godot/ImGuiGodot/Internal/CanvasRenderer.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/CanvasRenderer.cs
@@ -147,7 +147,7 @@ internal class CanvasRenderer : IRenderer
 
                 Rid child = children[nodeN++];
 
-                Rid texRid = Util.ConstructRid((ulong)drawCmd.GetTexID());
+                Rid texrid = Util.ConstructRid((ulong)drawCmd.GetTexID());
                 RenderingServer.CanvasItemClear(child);
                 Transform2D xform = Transform2D.Identity;
                 if (drawData.DisplayPos != System.Numerics.Vector2.Zero)
@@ -163,7 +163,7 @@ internal class CanvasRenderer : IRenderer
                     drawCmd.ClipRect.W - drawCmd.ClipRect.Y)
                 );
 
-                RenderingServer.CanvasItemAddTriangleArray(child, indices, cmdvertices, cmdcolors, cmduvs, null, null, texRid, -1);
+                RenderingServer.CanvasItemAddTriangleArray(child, indices, cmdvertices, cmdcolors, cmduvs, null, null, texrid, -1);
             }
         }
     }

--- a/addons/imgui-godot/ImGuiGodot/Internal/Input.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/Input.cs
@@ -17,7 +17,7 @@ internal static class Input
         if (io.ConfigFlags.HasFlag(ImGuiConfigFlags.ViewportsEnable))
         {
             var mousePos = DisplayServer.MouseGetPosition();
-            io.AddMousePosEvent(mousePos.x, mousePos.y);
+            io.AddMousePosEvent(mousePos.X, mousePos.Y);
 
             if (io.WantSetMousePos)
             {
@@ -33,7 +33,7 @@ internal static class Input
         // scrolling works better if we allow no more than one event per frame
         if (_mouseWheel != Vector2.Zero)
         {
-            io.AddMouseWheelEvent(_mouseWheel.x, _mouseWheel.y);
+            io.AddMouseWheelEvent(_mouseWheel.X, _mouseWheel.Y);
             _mouseWheel = Vector2.Zero;
         }
 
@@ -59,7 +59,7 @@ internal static class Input
         var io = ImGui.GetIO();
         bool viewportsEnable = io.ConfigFlags.HasFlag(ImGuiConfigFlags.ViewportsEnable);
 
-        var windowPos = Vector2i.Zero;
+        var windowPos = Vector2I.Zero;
         if (viewportsEnable)
             windowPos = window.Position;
 
@@ -68,8 +68,8 @@ internal static class Input
             var vpEvent = evt.Duplicate() as InputEvent;
             if (vpEvent is InputEventMouse mouseEvent)
             {
-                mouseEvent.Position = new Vector2(windowPos.x + mouseEvent.GlobalPosition.x - CurrentSubViewportPos.X,
-                    windowPos.y + mouseEvent.GlobalPosition.y - CurrentSubViewportPos.Y)
+                mouseEvent.Position = new Vector2(windowPos.X + mouseEvent.GlobalPosition.X - CurrentSubViewportPos.X,
+                    windowPos.Y + mouseEvent.GlobalPosition.Y - CurrentSubViewportPos.Y)
                     .Clamp(Vector2.Zero, CurrentSubViewport.Size);
             }
             CurrentSubViewport.PushInput(vpEvent, true);
@@ -84,7 +84,7 @@ internal static class Input
         if (evt is InputEventMouseMotion mm)
         {
             if (!viewportsEnable)
-                io.AddMousePosEvent(mm.GlobalPosition.x, mm.GlobalPosition.y);
+                io.AddMousePosEvent(mm.GlobalPosition.X, mm.GlobalPosition.Y);
             consumed = io.WantCaptureMouse;
         }
         else if (evt is InputEventMouseButton mb)
@@ -107,16 +107,16 @@ internal static class Input
                     io.AddMouseButtonEvent((int)ImGuiMouseButton.Middle + 2, mb.Pressed);
                     break;
                 case MouseButton.WheelUp:
-                    _mouseWheel.y = mb.Factor;
+                    _mouseWheel.Y = mb.Factor;
                     break;
                 case MouseButton.WheelDown:
-                    _mouseWheel.y = -mb.Factor;
+                    _mouseWheel.Y = -mb.Factor;
                     break;
                 case MouseButton.WheelLeft:
-                    _mouseWheel.x = -mb.Factor;
+                    _mouseWheel.X = -mb.Factor;
                     break;
                 case MouseButton.WheelRight:
-                    _mouseWheel.x = mb.Factor;
+                    _mouseWheel.X = mb.Factor;
                     break;
             };
             consumed = io.WantCaptureMouse;
@@ -138,7 +138,7 @@ internal static class Input
         }
         else if (evt is InputEventPanGesture pg)
         {
-            _mouseWheel = new(-pg.Delta.x, -pg.Delta.y);
+            _mouseWheel = new(-pg.Delta.X, -pg.Delta.Y);
             consumed = io.WantCaptureMouse;
         }
         else if (io.ConfigFlags.HasFlag(ImGuiConfigFlags.NavEnableGamepad))

--- a/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
@@ -202,14 +202,14 @@ internal class RdRenderer : IRenderer
                 _usedTextures.Add(texid);
                 if (!_uniformSets.ContainsKey(texid))
                 {
-                    Rid texRid = RenderingServer.TextureGetRdTexture(Util.ConstructRid((ulong)texid));
+                    Rid texrid = RenderingServer.TextureGetRdTexture(Util.ConstructRid((ulong)texid));
                     using RDUniform uniform = new()
                     {
                         Binding = 0,
                         UniformType = RenderingDevice.UniformType.SamplerWithTexture
                     };
                     uniform.AddId(_sampler);
-                    uniform.AddId(texRid);
+                    uniform.AddId(texrid);
                     _uniformArray[0] = uniform;
                     Rid uniformSet = RD.UniformSetCreate(_uniformArray, _shader, 0);
                     _uniformSets[texid] = uniformSet;

--- a/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
@@ -11,27 +11,27 @@ internal class RdRenderer : IRenderer
 {
     private readonly RenderingDevice RD;
     private readonly Color[] _clearColors = { new Color(0f, 0f, 0f, 0f) };
-    private readonly RID _shader;
-    private readonly RID _pipeline;
-    private readonly RID _sampler;
+    private readonly Rid _shader;
+    private readonly Rid _pipeline;
+    private readonly Rid _sampler;
     private readonly long _vtxFormat;
-    private readonly Dictionary<RID, RID> _framebuffers = new();
+    private readonly Dictionary<Rid, Rid> _framebuffers = new();
     private readonly float[] _scale = new float[2];
     private readonly float[] _translate = new float[2];
     private readonly byte[] _pcbuf = new byte[16];
     private readonly ArrayPool<byte> _bufPool = ArrayPool<byte>.Create();
 
-    private RID _idxBuffer;
+    private Rid _idxBuffer;
     private int _idxBufferSize = 0; // size in indices
-    private RID _vtxBuffer;
+    private Rid _vtxBuffer;
     private int _vtxBufferSize = 0; // size in vertices
 
-    private readonly Dictionary<IntPtr, RID> _uniformSets = new(8);
+    private readonly Dictionary<IntPtr, Rid> _uniformSets = new(8);
     private readonly HashSet<IntPtr> _usedTextures = new(8);
 
     private readonly Rect2 _zeroRect = new(new(0f, 0f), new(0f, 0f));
     private readonly Godot.Collections.Array _storageTextures = new();
-    private readonly Godot.Collections.Array<RID> _srcBuffers = new();
+    private readonly Godot.Collections.Array<Rid> _srcBuffers = new();
     private readonly long[] _vtxOffsets = new long[3];
     private readonly Godot.Collections.Array<RDUniform> _uniformArray = new();
 
@@ -48,8 +48,8 @@ internal class RdRenderer : IRenderer
         // set up everything to match the official Vulkan backend as closely as possible
 
         // compiling from source takes ~400ms, so we use a SPIR-V resource
-        using var spirv = ResourceLoader.Load<RDShaderSPIRV>("res://addons/imgui-godot/ImGuiShaderSPIRV.tres");
-        _shader = RD.ShaderCreateFromSpirv(spirv);
+        using var spirv = ResourceLoader.Load<RDShaderSpirV>("res://addons/imgui-godot/ImGuiShaderSPIRV.tres");
+        _shader = RD.ShaderCreateFromSpirV(spirv);
 
 #if IMGUI_GODOT_DEV
 #pragma warning disable CA2201
@@ -67,29 +67,29 @@ internal class RdRenderer : IRenderer
 #endif
 
         // create vertex format
-        uint vtxStride = (uint)Marshal.SizeOf<ImDrawVert>();
+        uint vtxStRide = (uint)Marshal.SizeOf<ImDrawVert>();
 
         using RDVertexAttribute attrPoints = new()
         {
             Location = 0,
-            Format = RenderingDevice.DataFormat.R32g32Sfloat,
-            Stride = vtxStride,
+            Format = RenderingDevice.DataFormat.R32G32Sfloat,
+            Stride = vtxStRide,
             Offset = 0
         };
 
         using RDVertexAttribute attrUvs = new()
         {
             Location = 1,
-            Format = RenderingDevice.DataFormat.R32g32Sfloat,
-            Stride = vtxStride,
+            Format = RenderingDevice.DataFormat.R32G32Sfloat,
+            Stride = vtxStRide,
             Offset = sizeof(float) * 2
         };
 
         using RDVertexAttribute attrColors = new()
         {
             Location = 2,
-            Format = RenderingDevice.DataFormat.R8g8b8a8Unorm,
-            Stride = vtxStride,
+            Format = RenderingDevice.DataFormat.R8G8B8A8Unorm,
+            Stride = vtxStRide,
             Offset = sizeof(float) * 4
         };
 
@@ -202,16 +202,16 @@ internal class RdRenderer : IRenderer
                 _usedTextures.Add(texid);
                 if (!_uniformSets.ContainsKey(texid))
                 {
-                    RID texrid = RenderingServer.TextureGetRdTexture(Util.ConstructRID((ulong)texid));
+                    Rid texRid = RenderingServer.TextureGetRdTexture(Util.ConstructRid((ulong)texid));
                     using RDUniform uniform = new()
                     {
                         Binding = 0,
                         UniformType = RenderingDevice.UniformType.SamplerWithTexture
                     };
                     uniform.AddId(_sampler);
-                    uniform.AddId(texrid);
+                    uniform.AddId(texRid);
                     _uniformArray[0] = uniform;
-                    RID uniformSet = RD.UniformSetCreate(_uniformArray, _shader, 0);
+                    Rid uniformSet = RD.UniformSetCreate(_uniformArray, _shader, 0);
                     _uniformSets[texid] = uniformSet;
                 }
             }
@@ -227,7 +227,7 @@ internal class RdRenderer : IRenderer
 #if IMGUI_GODOT_DEV
         RD.DrawCommandBeginLabel("ImGui", Colors.Purple);
 #endif
-        RID fb = GetFramebuffer(vp);
+        Rid fb = GetFramebuffer(vp);
 
         int vertSize = Marshal.SizeOf<ImDrawVert>();
 
@@ -289,14 +289,14 @@ internal class RdRenderer : IRenderer
                 if (drawCmd.ElemCount == 0)
                     continue;
 
-                RID idxArray = RD.IndexArrayCreate(_idxBuffer,
+                Rid idxArray = RD.IndexArrayCreate(_idxBuffer,
                     (uint)(drawCmd.IdxOffset + globalIdxOffset),
                     drawCmd.ElemCount);
 
                 long voff = (drawCmd.VtxOffset + globalVtxOffset) * vertSize;
                 _srcBuffers[0] = _srcBuffers[1] = _srcBuffers[2] = _vtxBuffer;
                 _vtxOffsets[0] = _vtxOffsets[1] = _vtxOffsets[2] = voff;
-                RID vtxArray = RD.VertexArrayCreate(
+                Rid vtxArray = RD.VertexArrayCreate(
                     (uint)cmdList.VtxBuffer.Size,
                     _vtxFormat,
                     _srcBuffers,
@@ -311,7 +311,7 @@ internal class RdRenderer : IRenderer
                     drawCmd.ClipRect.Y,
                     drawCmd.ClipRect.Z - drawCmd.ClipRect.X,
                     drawCmd.ClipRect.W - drawCmd.ClipRect.Y);
-                clipRect.Position -= drawData.DisplayPos.ToVector2i();
+                clipRect.Position -= drawData.DisplayPos.ToVector2I();
                 RD.DrawListEnableScissor(dl, clipRect);
 
                 RD.DrawListDraw(dl, true, 1);
@@ -352,18 +352,18 @@ internal class RdRenderer : IRenderer
             RD.FreeRid(_vtxBuffer);
     }
 
-    private RID GetFramebuffer(Viewport vp)
+    private Rid GetFramebuffer(Viewport vp)
     {
-        RID vprid = vp.GetViewportRid();
-        if (_framebuffers.TryGetValue(vprid, out RID fb))
+        Rid vpRid = vp.GetViewportRid();
+        if (_framebuffers.TryGetValue(vpRid, out Rid fb))
         {
             if (RD.FramebufferIsValid(fb))
                 return fb;
         }
 
-        RID vptex = RenderingServer.TextureGetRdTexture(vp.GetTexture().GetRid());
+        Rid vptex = RenderingServer.TextureGetRdTexture(vp.GetTexture().GetRid());
         fb = RD.FramebufferCreate(new() { vptex });
-        _framebuffers[vprid] = fb;
+        _framebuffers[vpRid] = fb;
         return fb;
     }
 

--- a/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
@@ -67,13 +67,13 @@ internal class RdRenderer : IRenderer
 #endif
 
         // create vertex format
-        uint vtxStRide = (uint)Marshal.SizeOf<ImDrawVert>();
+        uint vtxStride = (uint)Marshal.SizeOf<ImDrawVert>();
 
         using RDVertexAttribute attrPoints = new()
         {
             Location = 0,
             Format = RenderingDevice.DataFormat.R32G32Sfloat,
-            Stride = vtxStRide,
+            Stride = vtxStride,
             Offset = 0
         };
 
@@ -81,7 +81,7 @@ internal class RdRenderer : IRenderer
         {
             Location = 1,
             Format = RenderingDevice.DataFormat.R32G32Sfloat,
-            Stride = vtxStRide,
+            Stride = vtxStride,
             Offset = sizeof(float) * 2
         };
 
@@ -89,7 +89,7 @@ internal class RdRenderer : IRenderer
         {
             Location = 2,
             Format = RenderingDevice.DataFormat.R8G8B8A8Unorm,
-            Stride = vtxStRide,
+            Stride = vtxStride,
             Offset = sizeof(float) * 4
         };
 

--- a/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/RdRenderer.cs
@@ -354,8 +354,8 @@ internal class RdRenderer : IRenderer
 
     private Rid GetFramebuffer(Viewport vp)
     {
-        Rid vpRid = vp.GetViewportRid();
-        if (_framebuffers.TryGetValue(vpRid, out Rid fb))
+        Rid vprid = vp.GetViewportRid();
+        if (_framebuffers.TryGetValue(vprid, out Rid fb))
         {
             if (RD.FramebufferIsValid(fb))
                 return fb;
@@ -363,7 +363,7 @@ internal class RdRenderer : IRenderer
 
         Rid vptex = RenderingServer.TextureGetRdTexture(vp.GetTexture().GetRid());
         fb = RD.FramebufferCreate(new() { vptex });
-        _framebuffers[vpRid] = fb;
+        _framebuffers[vprid] = fb;
         return fb;
     }
 

--- a/addons/imgui-godot/ImGuiGodot/Internal/Util.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/Util.cs
@@ -7,22 +7,22 @@ namespace ImGuiGodot.Internal;
 
 internal static class Util
 {
-    public static readonly Func<ulong, RID> ConstructRID;
+    public static readonly Func<ulong, Rid> ConstructRid;
 
     static Util()
     {
-        ConstructorInfo cinfo = typeof(RID).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, new[] { typeof(ulong) });
+        ConstructorInfo cinfo = typeof(Rid).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, new[] { typeof(ulong) });
         if (cinfo is null)
         {
-            throw new PlatformNotSupportedException("failed to get RID constructor");
+            throw new PlatformNotSupportedException("failed to get Rid constructor");
         }
 
-        DynamicMethod dm = new("ConstructRID", typeof(RID), new[] { typeof(ulong) });
+        DynamicMethod dm = new("ConstructRid", typeof(Rid), new[] { typeof(ulong) });
         ILGenerator il = dm.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Newobj, cinfo);
         il.Emit(OpCodes.Ret);
-        ConstructRID = dm.CreateDelegate<Func<ulong, RID>>();
+        ConstructRid = dm.CreateDelegate<Func<ulong, Rid>>();
     }
 
     public static void AddLayerSubViewport(Node parent, out SubViewportContainer subViewportContainer, out SubViewport subViewport)

--- a/addons/imgui-godot/ImGuiGodot/Internal/Viewports.cs
+++ b/addons/imgui-godot/ImGuiGodot/Internal/Viewports.cs
@@ -20,7 +20,7 @@ internal class GodotImGuiWindow : IDisposable
         _vp = vp;
         _vp.PlatformHandle = (IntPtr)_gcHandle;
 
-        Rect2i winRect = new(_vp.Pos.ToVector2i(), _vp.Size.ToVector2i());
+        Rect2I winRect = new(_vp.Pos.ToVector2I(), _vp.Size.ToVector2I());
 
         ImGuiLayer.Instance.GetViewport().GuiEmbedSubwindows = false;
 
@@ -76,22 +76,22 @@ internal class GodotImGuiWindow : IDisposable
         GodotWindow.Show();
     }
 
-    public void SetWindowPos(Vector2i pos)
+    public void SetWindowPos(Vector2I pos)
     {
         GodotWindow.Position = pos;
     }
 
-    public Vector2i GetWindowPos()
+    public Vector2I GetWindowPos()
     {
         return GodotWindow.Position;
     }
 
-    public void SetWindowSize(Vector2i size)
+    public void SetWindowSize(Vector2I size)
     {
         GodotWindow.Size = size;
     }
 
-    public Vector2i GetWindowSize()
+    public Vector2I GetWindowSize()
     {
         return GodotWindow.Size;
     }
@@ -171,14 +171,14 @@ internal static class Viewports
     //private static bool _wantUpdateMonitors = true;
     private static GodotImGuiWindow _mainWindow;
 
-    internal static Vector2 ToImVec2(this Vector2i v)
+    internal static Vector2 ToImVec2(this Vector2I v)
     {
-        return new Vector2(v.x, v.y);
+        return new Vector2(v.X, v.Y);
     }
 
-    internal static Vector2i ToVector2i(this Vector2 v)
+    internal static Vector2I ToVector2I(this Vector2 v)
     {
-        return new Vector2i((int)v.X, (int)v.Y);
+        return new Vector2I((int)v.X, (int)v.Y);
     }
 
     private static void UpdateMonitors()
@@ -273,7 +273,7 @@ internal static class Viewports
     private static void Godot_SetWindowPos(ImGuiViewportPtr vp, Vector2 pos)
     {
         var window = (GodotImGuiWindow)GCHandle.FromIntPtr(vp.PlatformHandle).Target;
-        window.SetWindowPos(pos.ToVector2i());
+        window.SetWindowPos(pos.ToVector2I());
     }
 
     private static void Godot_GetWindowPos(ImGuiViewportPtr vp, out Vector2 pos)
@@ -285,7 +285,7 @@ internal static class Viewports
     private static void Godot_SetWindowSize(ImGuiViewportPtr vp, Vector2 size)
     {
         var window = (GodotImGuiWindow)GCHandle.FromIntPtr(vp.PlatformHandle).Target;
-        window.SetWindowSize(size.ToVector2i());
+        window.SetWindowSize(size.ToVector2I());
     }
 
     private static void Godot_GetWindowSize(ImGuiViewportPtr vp, out Vector2 size)

--- a/addons/imgui-godot/ImGuiGodot/Widgets.cs
+++ b/addons/imgui-godot/ImGuiGodot/Widgets.cs
@@ -19,7 +19,7 @@ public static class Widgets
     /// </returns>
     public static bool SubViewport(SubViewport vp)
     {
-        Vector2 vpSize = new(vp.Size.x, vp.Size.y);
+        Vector2 vpSize = new(vp.Size.X, vp.Size.Y);
         var pos = ImGui.GetCursorScreenPos();
         var pos_max = new Vector2(pos.X + vpSize.X, pos.Y + vpSize.Y);
         ImGui.GetWindowDrawList().AddImage((IntPtr)vp.GetTexture().GetRid().Id, pos, pos_max);


### PR DESCRIPTION
I don't expect this to be merged until the project is ready to support the latest GodotSharp, of course. 😆 

Fixes #26 